### PR TITLE
Fix remote code execution #2

### DIFF
--- a/Web/music/seek/index.php
+++ b/Web/music/seek/index.php
@@ -1,3 +1,3 @@
 <?php
-shell_exec('mpc seek '.$_GET['timepercent'].'%');
+shell_exec('mpc seek '.escapeshellarg($_GET['timepercent']).'%');
 ?>


### PR DESCRIPTION
RCE bug in Web/music/volume/index.php fixed.

You could send a request like the following to execute the `id` command:
```
GET /Web/music/seek/index.php?timepercent=;id
```

If accepting args to the commandline, do escape them.